### PR TITLE
Fix the error that occurred after a yarn upgrade

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
-const server = require('@storybook/core/server');
+const server = require('@storybook/core-server');
 const isVue3 = require('./isVue3');
 
 // eslint-disable-next-line import/no-unresolved


### PR DESCRIPTION
$ yarn storybook:build
yarn run v1.22.19
$ yarn storybook:build:stories && vue-cli-service storybook:build
$ node tools/buildDefaultStories.cjs
node:internal/modules/cjs/loader:936
  throw err;
  ^
Error: Cannot find module '@storybook/core/server'
Require stack:
- C:\Users\mejia\Git\vue-ui\node_modules\vue-cli-plugin-storybook\lib\index.js
- C:\Users\mejia\Git\vue-ui\node_modules\@vue\cli-service\lib\Service.js
- C:\Users\mejia\Git\vue-ui\node_modules\@vue\cli-service\bin\vue-cli-service.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (C:\Users\mejia\Git\vue-ui\node_modules\vue-cli-plugin-storybook\lib\index.js:2:16)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'C:\\Users\\mejia\\Git\\vue-ui\\node_modules\\vue-cli-plugin-storybook\\lib\\index.js',
    'C:\\Users\\mejia\\Git\\vue-ui\\node_modules\\@vue\\cli-service\\lib\\Service.js',
    'C:\\Users\\mejia\\Git\\vue-ui\\node_modules\\@vue\\cli-service\\bin\\vue-cli-service.js'
  ]
}